### PR TITLE
Update example.ipynb for preprocessing

### DIFF
--- a/example.ipynb
+++ b/example.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,12 +46,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Read In Data to Dataframe"
+    "### Read In Data to the DataFrame"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -160,7 +160,7 @@
        "4   5      AS     108         ANC       SEA          3    30     202      0"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -173,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -304,7 +304,7 @@
        "max       655.000000       1.000000  "
       ]
      },
-     "execution_count": 4,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -315,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -324,7 +324,7 @@
        "293"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -335,148 +335,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>id</th>\n",
-       "      <th>Airline</th>\n",
-       "      <th>Flight</th>\n",
-       "      <th>AirportFrom</th>\n",
-       "      <th>AirportTo</th>\n",
-       "      <th>DayOfWeek</th>\n",
-       "      <th>Time</th>\n",
-       "      <th>Length</th>\n",
-       "      <th>Delay</th>\n",
-       "      <th>Time_encoded</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>CO</td>\n",
-       "      <td>269</td>\n",
-       "      <td>SFO</td>\n",
-       "      <td>IAH</td>\n",
-       "      <td>3</td>\n",
-       "      <td>15</td>\n",
-       "      <td>205</td>\n",
-       "      <td>1</td>\n",
-       "      <td>00:15</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>US</td>\n",
-       "      <td>1558</td>\n",
-       "      <td>PHX</td>\n",
-       "      <td>CLT</td>\n",
-       "      <td>3</td>\n",
-       "      <td>15</td>\n",
-       "      <td>222</td>\n",
-       "      <td>1</td>\n",
-       "      <td>00:15</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3</td>\n",
-       "      <td>AA</td>\n",
-       "      <td>2400</td>\n",
-       "      <td>LAX</td>\n",
-       "      <td>DFW</td>\n",
-       "      <td>3</td>\n",
-       "      <td>20</td>\n",
-       "      <td>165</td>\n",
-       "      <td>1</td>\n",
-       "      <td>00:20</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>4</td>\n",
-       "      <td>AA</td>\n",
-       "      <td>2466</td>\n",
-       "      <td>SFO</td>\n",
-       "      <td>DFW</td>\n",
-       "      <td>3</td>\n",
-       "      <td>20</td>\n",
-       "      <td>195</td>\n",
-       "      <td>1</td>\n",
-       "      <td>00:20</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>5</td>\n",
-       "      <td>AS</td>\n",
-       "      <td>108</td>\n",
-       "      <td>ANC</td>\n",
-       "      <td>SEA</td>\n",
-       "      <td>3</td>\n",
-       "      <td>30</td>\n",
-       "      <td>202</td>\n",
-       "      <td>0</td>\n",
-       "      <td>00:30</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   id Airline  Flight AirportFrom AirportTo  DayOfWeek  Time  Length  Delay  \\\n",
-       "0   1      CO     269         SFO       IAH          3    15     205      1   \n",
-       "1   2      US    1558         PHX       CLT          3    15     222      1   \n",
-       "2   3      AA    2400         LAX       DFW          3    20     165      1   \n",
-       "3   4      AA    2466         SFO       DFW          3    20     195      1   \n",
-       "4   5      AS     108         ANC       SEA          3    30     202      0   \n",
-       "\n",
-       "  Time_encoded  \n",
-       "0        00:15  \n",
-       "1        00:15  \n",
-       "2        00:20  \n",
-       "3        00:20  \n",
-       "4        00:30  "
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "df['Time_encoded'] = df['Time'].apply(lambda x: f\"{x // 60:02d}:{x % 60:02d}\")\n",
-    "df.head()"
+    "# Commenting out the time encoding since this gets formatted as a string and cannot be used for clustering\n",
+    "# df['Time_encoded'] = df['Time'].apply(lambda x: f\"{x // 60:02d}:{x % 60:02d}\")\n",
+    "# df.head()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Preprocessing : Encoding 'AirportFrom', 'AirportTo', 'Airline' Columns"
+    "### Preprocessing: Encoding 'AirportFrom', 'AirportTo', 'Airline' Columns"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -517,7 +394,7 @@
        "       'ADK', 'ABR', 'TEX', 'MMH', 'GUM'], dtype=object)"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -531,12 +408,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Make a copy of Dataframe for preprocessing"
+    "### Make a copy of the DataFrame for preprocessing"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -545,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -578,7 +455,6 @@
        "      <th>Time</th>\n",
        "      <th>Length</th>\n",
        "      <th>Delay</th>\n",
-       "      <th>Time_encoded</th>\n",
        "      <th>AirportFroIDs</th>\n",
        "      <th>AirportToIDs</th>\n",
        "    </tr>\n",
@@ -595,7 +471,6 @@
        "      <td>15</td>\n",
        "      <td>205</td>\n",
        "      <td>1</td>\n",
-       "      <td>00:15</td>\n",
        "      <td>1</td>\n",
        "      <td>103</td>\n",
        "    </tr>\n",
@@ -610,7 +485,6 @@
        "      <td>15</td>\n",
        "      <td>222</td>\n",
        "      <td>1</td>\n",
-       "      <td>00:15</td>\n",
        "      <td>2</td>\n",
        "      <td>109</td>\n",
        "    </tr>\n",
@@ -625,7 +499,6 @@
        "      <td>20</td>\n",
        "      <td>165</td>\n",
        "      <td>1</td>\n",
-       "      <td>00:20</td>\n",
        "      <td>3</td>\n",
        "      <td>72</td>\n",
        "    </tr>\n",
@@ -640,7 +513,6 @@
        "      <td>20</td>\n",
        "      <td>195</td>\n",
        "      <td>1</td>\n",
-       "      <td>00:20</td>\n",
        "      <td>1</td>\n",
        "      <td>72</td>\n",
        "    </tr>\n",
@@ -655,13 +527,11 @@
        "      <td>30</td>\n",
        "      <td>202</td>\n",
        "      <td>0</td>\n",
-       "      <td>00:30</td>\n",
        "      <td>4</td>\n",
        "      <td>22</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
-       "      <td>...</td>\n",
        "      <td>...</td>\n",
        "      <td>...</td>\n",
        "      <td>...</td>\n",
@@ -685,7 +555,6 @@
        "      <td>1439</td>\n",
        "      <td>326</td>\n",
        "      <td>0</td>\n",
-       "      <td>23:59</td>\n",
        "      <td>194</td>\n",
        "      <td>229</td>\n",
        "    </tr>\n",
@@ -700,7 +569,6 @@
        "      <td>1439</td>\n",
        "      <td>305</td>\n",
        "      <td>0</td>\n",
-       "      <td>23:59</td>\n",
        "      <td>22</td>\n",
        "      <td>55</td>\n",
        "    </tr>\n",
@@ -715,7 +583,6 @@
        "      <td>1439</td>\n",
        "      <td>255</td>\n",
        "      <td>0</td>\n",
-       "      <td>23:59</td>\n",
        "      <td>1</td>\n",
        "      <td>17</td>\n",
        "    </tr>\n",
@@ -730,7 +597,6 @@
        "      <td>1439</td>\n",
        "      <td>313</td>\n",
        "      <td>1</td>\n",
-       "      <td>23:59</td>\n",
        "      <td>12</td>\n",
        "      <td>1</td>\n",
        "    </tr>\n",
@@ -745,13 +611,12 @@
        "      <td>1439</td>\n",
        "      <td>301</td>\n",
        "      <td>1</td>\n",
-       "      <td>23:59</td>\n",
        "      <td>3</td>\n",
        "      <td>54</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>539383 rows × 12 columns</p>\n",
+       "<p>539383 rows × 11 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -768,23 +633,23 @@
        "539381  539382      UA      78         HNL       SFO          5  1439     313   \n",
        "539382  539383      US    1442         LAX       PHL          5  1439     301   \n",
        "\n",
-       "        Delay Time_encoded  AirportFroIDs  AirportToIDs  \n",
-       "0           1        00:15              1           103  \n",
-       "1           1        00:15              2           109  \n",
-       "2           1        00:20              3            72  \n",
-       "3           1        00:20              1            72  \n",
-       "4           0        00:30              4            22  \n",
-       "...       ...          ...            ...           ...  \n",
-       "539378      0        23:59            194           229  \n",
-       "539379      0        23:59             22            55  \n",
-       "539380      0        23:59              1            17  \n",
-       "539381      1        23:59             12             1  \n",
-       "539382      1        23:59              3            54  \n",
+       "        Delay  AirportFroIDs  AirportToIDs  \n",
+       "0           1              1           103  \n",
+       "1           1              2           109  \n",
+       "2           1              3            72  \n",
+       "3           1              1            72  \n",
+       "4           0              4            22  \n",
+       "...       ...            ...           ...  \n",
+       "539378      0            194           229  \n",
+       "539379      0             22            55  \n",
+       "539380      0              1            17  \n",
+       "539381      1             12             1  \n",
+       "539382      1              3            54  \n",
        "\n",
-       "[539383 rows x 12 columns]"
+       "[539383 rows x 11 columns]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -802,7 +667,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -835,10 +700,9 @@
        "      <th>Time</th>\n",
        "      <th>Length</th>\n",
        "      <th>Delay</th>\n",
-       "      <th>Time_encoded</th>\n",
        "      <th>AirportFroIDs</th>\n",
        "      <th>AirportToIDs</th>\n",
-       "      <th>airline_id</th>\n",
+       "      <th>AirlineID</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -853,7 +717,6 @@
        "      <td>15</td>\n",
        "      <td>205</td>\n",
        "      <td>1</td>\n",
-       "      <td>00:15</td>\n",
        "      <td>1</td>\n",
        "      <td>103</td>\n",
        "      <td>2824</td>\n",
@@ -869,7 +732,6 @@
        "      <td>15</td>\n",
        "      <td>222</td>\n",
        "      <td>1</td>\n",
-       "      <td>00:15</td>\n",
        "      <td>2</td>\n",
        "      <td>109</td>\n",
        "      <td>1409</td>\n",
@@ -885,7 +747,6 @@
        "      <td>20</td>\n",
        "      <td>165</td>\n",
        "      <td>1</td>\n",
-       "      <td>00:20</td>\n",
        "      <td>3</td>\n",
        "      <td>72</td>\n",
        "      <td>5506</td>\n",
@@ -901,7 +762,6 @@
        "      <td>20</td>\n",
        "      <td>195</td>\n",
        "      <td>1</td>\n",
-       "      <td>00:20</td>\n",
        "      <td>1</td>\n",
        "      <td>72</td>\n",
        "      <td>5506</td>\n",
@@ -917,7 +777,6 @@
        "      <td>30</td>\n",
        "      <td>202</td>\n",
        "      <td>0</td>\n",
-       "      <td>00:30</td>\n",
        "      <td>4</td>\n",
        "      <td>22</td>\n",
        "      <td>5012</td>\n",
@@ -934,15 +793,15 @@
        "3   4      AA    2466         SFO       DFW          3    20     195      1   \n",
        "4   5      AS     108         ANC       SEA          3    30     202      0   \n",
        "\n",
-       "  Time_encoded  AirportFroIDs  AirportToIDs  airline_id  \n",
-       "0        00:15              1           103        2824  \n",
-       "1        00:15              2           109        1409  \n",
-       "2        00:20              3            72        5506  \n",
-       "3        00:20              1            72        5506  \n",
-       "4        00:30              4            22        5012  "
+       "   AirportFroIDs  AirportToIDs  AirlineID  \n",
+       "0              1           103       2824  \n",
+       "1              2           109       1409  \n",
+       "2              3            72       5506  \n",
+       "3              1            72       5506  \n",
+       "4              4            22       5012  "
       ]
      },
-     "execution_count": 10,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -956,14 +815,14 @@
     "airline_to_id = {airline: random.randint(1000, 9999) for airline in unique_airlines}\n",
     "\n",
     "# Apply the random mapping to the airline column\n",
-    "encoded_df['airline_id'] = encoded_df['Airline'].map(airline_to_id)\n",
+    "encoded_df['AirlineID'] = encoded_df['Airline'].map(airline_to_id)\n",
     "\n",
     "encoded_df.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -972,7 +831,7 @@
        "293"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -983,7 +842,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -992,7 +851,7 @@
        "293"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1003,7 +862,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -1033,10 +892,9 @@
        "      <th>Time</th>\n",
        "      <th>Length</th>\n",
        "      <th>Delay</th>\n",
-       "      <th>Time_encoded</th>\n",
        "      <th>AirportFroIDs</th>\n",
        "      <th>AirportToIDs</th>\n",
-       "      <th>airline_id</th>\n",
+       "      <th>AirlineID</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -1048,7 +906,6 @@
        "      <td>15</td>\n",
        "      <td>205</td>\n",
        "      <td>1</td>\n",
-       "      <td>00:15</td>\n",
        "      <td>1</td>\n",
        "      <td>103</td>\n",
        "      <td>2824</td>\n",
@@ -1061,7 +918,6 @@
        "      <td>15</td>\n",
        "      <td>222</td>\n",
        "      <td>1</td>\n",
-       "      <td>00:15</td>\n",
        "      <td>2</td>\n",
        "      <td>109</td>\n",
        "      <td>1409</td>\n",
@@ -1074,7 +930,6 @@
        "      <td>20</td>\n",
        "      <td>165</td>\n",
        "      <td>1</td>\n",
-       "      <td>00:20</td>\n",
        "      <td>3</td>\n",
        "      <td>72</td>\n",
        "      <td>5506</td>\n",
@@ -1087,7 +942,6 @@
        "      <td>20</td>\n",
        "      <td>195</td>\n",
        "      <td>1</td>\n",
-       "      <td>00:20</td>\n",
        "      <td>1</td>\n",
        "      <td>72</td>\n",
        "      <td>5506</td>\n",
@@ -1100,7 +954,6 @@
        "      <td>30</td>\n",
        "      <td>202</td>\n",
        "      <td>0</td>\n",
-       "      <td>00:30</td>\n",
        "      <td>4</td>\n",
        "      <td>22</td>\n",
        "      <td>5012</td>\n",
@@ -1110,22 +963,22 @@
        "</div>"
       ],
       "text/plain": [
-       "   id  Flight  DayOfWeek  Time  Length  Delay Time_encoded  AirportFroIDs  \\\n",
-       "0   1     269          3    15     205      1        00:15              1   \n",
-       "1   2    1558          3    15     222      1        00:15              2   \n",
-       "2   3    2400          3    20     165      1        00:20              3   \n",
-       "3   4    2466          3    20     195      1        00:20              1   \n",
-       "4   5     108          3    30     202      0        00:30              4   \n",
+       "   id  Flight  DayOfWeek  Time  Length  Delay  AirportFroIDs  AirportToIDs  \\\n",
+       "0   1     269          3    15     205      1              1           103   \n",
+       "1   2    1558          3    15     222      1              2           109   \n",
+       "2   3    2400          3    20     165      1              3            72   \n",
+       "3   4    2466          3    20     195      1              1            72   \n",
+       "4   5     108          3    30     202      0              4            22   \n",
        "\n",
-       "   AirportToIDs  airline_id  \n",
-       "0           103        2824  \n",
-       "1           109        1409  \n",
-       "2            72        5506  \n",
-       "3            72        5506  \n",
-       "4            22        5012  "
+       "   AirlineID  \n",
+       "0       2824  \n",
+       "1       1409  \n",
+       "2       5506  \n",
+       "3       5506  \n",
+       "4       5012  "
       ]
      },
-     "execution_count": 13,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1133,6 +986,129 @@
    "source": [
     "# Drop all the categorical columns\n",
     "encoded_df = encoded_df.drop(columns=['Airline', 'AirportFrom', 'AirportTo'])\n",
+    "encoded_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Flight</th>\n",
+       "      <th>DayOfWeek</th>\n",
+       "      <th>Time</th>\n",
+       "      <th>Length</th>\n",
+       "      <th>Delay</th>\n",
+       "      <th>AirportFroIDs</th>\n",
+       "      <th>AirportToIDs</th>\n",
+       "      <th>AirlineID</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>269</td>\n",
+       "      <td>3</td>\n",
+       "      <td>15</td>\n",
+       "      <td>205</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>103</td>\n",
+       "      <td>2824</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1558</td>\n",
+       "      <td>3</td>\n",
+       "      <td>15</td>\n",
+       "      <td>222</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>109</td>\n",
+       "      <td>1409</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2400</td>\n",
+       "      <td>3</td>\n",
+       "      <td>20</td>\n",
+       "      <td>165</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "      <td>72</td>\n",
+       "      <td>5506</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2466</td>\n",
+       "      <td>3</td>\n",
+       "      <td>20</td>\n",
+       "      <td>195</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>72</td>\n",
+       "      <td>5506</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>108</td>\n",
+       "      <td>3</td>\n",
+       "      <td>30</td>\n",
+       "      <td>202</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4</td>\n",
+       "      <td>22</td>\n",
+       "      <td>5012</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Flight  DayOfWeek  Time  Length  Delay  AirportFroIDs  AirportToIDs  \\\n",
+       "0     269          3    15     205      1              1           103   \n",
+       "1    1558          3    15     222      1              2           109   \n",
+       "2    2400          3    20     165      1              3            72   \n",
+       "3    2466          3    20     195      1              1            72   \n",
+       "4     108          3    30     202      0              4            22   \n",
+       "\n",
+       "   AirlineID  \n",
+       "0       2824  \n",
+       "1       1409  \n",
+       "2       5506  \n",
+       "3       5506  \n",
+       "4       5012  "
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Drop the id column since this is a hard-coded index\n",
+    "encoded_df = encoded_df.drop(columns=['id'])\n",
     "encoded_df.head()"
    ]
   }
@@ -1153,7 +1129,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/example.ipynb
+++ b/example.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,6 +37,7 @@
     "import random\n",
     "import matplotlib.pyplot as plt\n",
     "from sklearn.cluster import KMeans\n",
+    "from sklearn.model_selection import train_test_split\n",
     "from sklearn.preprocessing import StandardScaler\n",
     "from sklearn.decomposition import PCA\n",
     "from sklearn.preprocessing import LabelEncoder"
@@ -51,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [
     {
@@ -160,7 +161,7 @@
        "4   5      AS     108         ANC       SEA          3    30     202      0"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -173,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
@@ -304,7 +305,7 @@
        "max       655.000000       1.000000  "
       ]
      },
-     "execution_count": 30,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -315,7 +316,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [
     {
@@ -324,7 +325,7 @@
        "293"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -335,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [
     {
@@ -394,7 +395,7 @@
        "       'ADK', 'ABR', 'TEX', 'MMH', 'GUM'], dtype=object)"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 74,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -413,7 +414,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [
     {
@@ -649,7 +650,7 @@
        "[539383 rows x 11 columns]"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 76,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -667,7 +668,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [
     {
@@ -801,7 +802,7 @@
        "4              4            22       5012  "
       ]
      },
-     "execution_count": 36,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -822,7 +823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [
     {
@@ -831,7 +832,7 @@
        "293"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -842,7 +843,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [
     {
@@ -851,7 +852,7 @@
        "293"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -862,7 +863,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [
     {
@@ -978,7 +979,7 @@
        "4       5012  "
       ]
      },
-     "execution_count": 39,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -991,7 +992,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [
     {
@@ -1101,7 +1102,7 @@
        "4       5012  "
       ]
      },
-     "execution_count": 40,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1110,6 +1111,221 @@
     "# Drop the id column since this is a hard-coded index\n",
     "encoded_df = encoded_df.drop(columns=['id'])\n",
     "encoded_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare the data for modeling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Flight</th>\n",
+       "      <th>DayOfWeek</th>\n",
+       "      <th>Time</th>\n",
+       "      <th>Length</th>\n",
+       "      <th>AirportFroIDs</th>\n",
+       "      <th>AirportToIDs</th>\n",
+       "      <th>AirlineID</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>269</td>\n",
+       "      <td>3</td>\n",
+       "      <td>15</td>\n",
+       "      <td>205</td>\n",
+       "      <td>1</td>\n",
+       "      <td>103</td>\n",
+       "      <td>2824</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1558</td>\n",
+       "      <td>3</td>\n",
+       "      <td>15</td>\n",
+       "      <td>222</td>\n",
+       "      <td>2</td>\n",
+       "      <td>109</td>\n",
+       "      <td>1409</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2400</td>\n",
+       "      <td>3</td>\n",
+       "      <td>20</td>\n",
+       "      <td>165</td>\n",
+       "      <td>3</td>\n",
+       "      <td>72</td>\n",
+       "      <td>5506</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2466</td>\n",
+       "      <td>3</td>\n",
+       "      <td>20</td>\n",
+       "      <td>195</td>\n",
+       "      <td>1</td>\n",
+       "      <td>72</td>\n",
+       "      <td>5506</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>108</td>\n",
+       "      <td>3</td>\n",
+       "      <td>30</td>\n",
+       "      <td>202</td>\n",
+       "      <td>4</td>\n",
+       "      <td>22</td>\n",
+       "      <td>5012</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Flight  DayOfWeek  Time  Length  AirportFroIDs  AirportToIDs  AirlineID\n",
+       "0     269          3    15     205              1           103       2824\n",
+       "1    1558          3    15     222              2           109       1409\n",
+       "2    2400          3    20     165              3            72       5506\n",
+       "3    2466          3    20     195              1            72       5506\n",
+       "4     108          3    30     202              4            22       5012"
+      ]
+     },
+     "execution_count": 82,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Define X for training and testing and drop the Delay column since it's our target\n",
+    "X = encoded_df.copy()\n",
+    "X.drop('Delay', axis=1, inplace=True)\n",
+    "X.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the Delay column as our target\n",
+    "y = df['Delay']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Split the data into training and testing sets\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Scale the Data\n",
+    "SVM, KNN, K-Means, and PCA need scaling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[-1.09447296,  1.08199271,  0.01063145, ...,  1.82992654,\n",
+       "        -1.05211002, -0.75328146],\n",
+       "       [ 2.01121043, -1.00719177,  1.00286384, ...,  2.43184152,\n",
+       "        -0.19638348,  2.16454157],\n",
+       "       [-0.8346985 ,  0.55969659, -0.35246809, ..., -1.21132809,\n",
+       "        -0.38654493, -1.26398092],\n",
+       "       ...,\n",
+       "       [ 0.14828415, -1.00719177, -1.26920454, ...,  0.8636946 ,\n",
+       "        -0.83025499,  0.04212289],\n",
+       "       [ 1.46021769, -0.48489565, -0.83779915, ..., -0.37181509,\n",
+       "        -0.76686784, -1.21934498],\n",
+       "       [ 0.77038833, -0.48489565, -0.22664152, ...,  0.89537434,\n",
+       "        -0.19638348,  0.10405023]])"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Scaling the X train data by using StandardScaler()\n",
+    "scaler = StandardScaler().fit(X_train)\n",
+    "X_train_scaled = scaler.transform(X_train)\n",
+    "X_train_scaled"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[-1.13268931,  0.03740047, -0.99957617, ..., -1.21132809,\n",
+       "        -0.35485136, -1.26398092],\n",
+       "       [-0.45737249, -0.48489565, -1.44895678, ...,  0.3726587 ,\n",
+       "        -0.87779535, -0.11872733],\n",
+       "       [ 0.77232333,  0.55969659,  0.52831791, ...,  0.10338094,\n",
+       "        -0.37069815, -0.85582348],\n",
+       "       ...,\n",
+       "       [ 1.25752589, -1.52948788, -1.59275858, ...,  1.03793315,\n",
+       "        -0.37069815, -1.21934498],\n",
+       "       [ 0.59527036,  1.60428882,  1.08554987, ..., -1.21132809,\n",
+       "         0.94458524, -0.11872733],\n",
+       "       [-0.66054803,  0.55969659, -0.04688927, ..., -0.0708576 ,\n",
+       "         0.07301191, -0.50919125]])"
+      ]
+     },
+     "execution_count": 86,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Scale X test data by using StandardScaler()\n",
+    "X_test_scaled = scaler.transform(X_test)\n",
+    "X_test_scaled"
    ]
   }
  ],


### PR DESCRIPTION
# Overview
Updates the example workbook we're all using as our foundation for our AI models in project 2.

## Changes
1. Comments out the time encoding. This encoding was formatted as a string and was breaking scaling. Additionally, it appears that if we encode this as a datetime object, it would increase dimensionality. We can keep it as an integer.
2. Drops the 'id' column since it's a hard-coded index
3. Minor wording updates
4. Adds train, test, split
5. Adds standard scaler